### PR TITLE
Pulling Latest

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -54,6 +54,7 @@ Print manifest:
 
 	make manifest PROFILE="<profilename>" # override the default target profile
 	make manifest PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
+	make manifest STRIP_ABI=1 # remove ABI version from printed package names
 
 endef
 $(eval $(call shexport,Helptext))
@@ -129,7 +130,7 @@ _call_manifest: FORCE
 	mkdir -p $(TARGET_DIR) $(BIN_DIR) $(TMP_DIR) $(DL_DIR)
 	$(MAKE) package_reload >/dev/null
 	$(MAKE) package_install >/dev/null
-	$(OPKG) list-installed
+	$(OPKG) list-installed $(if $(STRIP_ABI),--strip-abi)
 
 package_index: FORCE
 	@echo >&2


### PR DESCRIPTION
The ImageBuilder `make manifest` prints all installed packages. This
function can be used to create a list of package and corresponding
package versions before attempting image creation.

When called with `--strip-abi` OPKG can automatically strip attached
ABIVersions from package names. Make this function accessible for the
ImageBuilder by adding a `STRIP_ABI` variable.

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit 0f7cd97f812adaf4b2c2048227610d150aec72cc)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
